### PR TITLE
Hide the schedule for now

### DIFF
--- a/src/components/Layout/MenuBar.astro
+++ b/src/components/Layout/MenuBar.astro
@@ -35,11 +35,6 @@ const menuData = [
         icon: "sponsors",
         link: "/#sponsors",
         name: "Sponsors"
-    },
-    {
-        icon: "calendar",
-        link: "/talks",
-        name: "Schedule"
     }
 ]
 ---

--- a/src/layouts/LayoutDefault.astro
+++ b/src/layouts/LayoutDefault.astro
@@ -30,7 +30,7 @@ import MenuBar from "../components/Layout/MenuBar.astro";
 	    <img src="/logo.png" alt="NixCon NA 2024 Pasadena " class="w-56 md:w-96" />
 	    </a>
 
-        <p class="text-2xl font-overpass bg-clip-text text-white mt-2">
+        <p class="text-2xl font-overpass bg-clip-text mt-2">
           March 14 – 15
         </p>
       </div>


### PR DESCRIPTION
This currently has the previous NixCon schedule, which might cause some confusion. I propose we hide it until the new schedule is ready.

(Also contains a small aesthetic fix.)