### PR TITLE
content/unhide-schedule

### DIFF
--- a/src/components/Layout/MenuBar.astro
+++ b/src/components/Layout/MenuBar.astro
@@ -35,6 +35,11 @@ const menuData = [
         icon: "sponsors",
         link: "/#sponsors",
         name: "Sponsors"
+    },
+    {
+        icon: "calendar",
+        link: "/talks",
+        name: "Schedule"
     }
 ]
 ---


### PR DESCRIPTION
Unhide schedule from menu bar.
The schedule has been announced so no need to hide it.