### PR TITLE
content/fix-schedule-descriptions

### DIFF
--- a/src/components/common/Schedule.astro
+++ b/src/components/common/Schedule.astro
@@ -178,7 +178,7 @@ let data = addStartOfDayEntry(parseSchedule(getDailyData(schedule)))
                         </p>
 
                         {item.description !== null ? (
-                            <div class="p-2 talk-abstract" set:html={marked.parse(item.description)}/>
+                            <div class="p-2 talk-abstract prose max-w-none text-white marker:text-white" set:html={marked.parse(item.description)}/>
                         ) : null }
                     </div>
                 </div>

--- a/src/components/common/Schedule.astro
+++ b/src/components/common/Schedule.astro
@@ -178,7 +178,7 @@ let data = addStartOfDayEntry(parseSchedule(getDailyData(schedule)))
                         </p>
 
                         {item.description !== null ? (
-                            <div class="p-2 talk-abstract prose max-w-none dark:text-white marker:text-white" set:html={marked.parse(item.description)}/>
+                            <div class="p-2 talk-abstract prose max-w-none dark:text-white marker:dark:text-white" set:html={marked.parse(item.description)}/>
                         ) : null }
                     </div>
                 </div>

--- a/src/components/common/Schedule.astro
+++ b/src/components/common/Schedule.astro
@@ -178,7 +178,7 @@ let data = addStartOfDayEntry(parseSchedule(getDailyData(schedule)))
                         </p>
 
                         {item.description !== null ? (
-                            <div class="p-2 talk-abstract prose max-w-none text-white marker:text-white" set:html={marked.parse(item.description)}/>
+                            <div class="p-2 talk-abstract prose max-w-none dark:text-white marker:text-white" set:html={marked.parse(item.description)}/>
                         ) : null }
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #33 
Fixes talks/workshops descriptions formatting on the schedule page.