### PR TITLE
content: remove template text

### DIFF
--- a/src/components/sections/AboutSection.astro
+++ b/src/components/sections/AboutSection.astro
@@ -13,6 +13,10 @@ import SectionParagraph from "../common/Section/SectionParagraph.astro";
     future development.
   </SectionParagraph>
   <SectionParagraph>
+    Join us for the first NixCon North America! Check out the
+    <a href="talks">schedule</a> for two days of talks, workshops, and hangouts.
+  </SectionParagraph>
+  <SectionParagraph>
     We would like to learn about how you use Nix and NixOS in your organization
     and what you are currently working on.
   </SectionParagraph>

--- a/src/components/sections/FAQSection.astro
+++ b/src/components/sections/FAQSection.astro
@@ -17,11 +17,8 @@ import ListItem from "../common/ListItem.astro";
     <SubSectionHeading id="volunteer">I am interested in helping? What can I do?</SubSectionHeading>
     <SectionParagraph>
         We are actively looking for volunteers for before, during and after the event.
-        If you are interested please, ...
-    </SectionParagraph>
-
-    <SectionParagraph>
-        There is also a Matrix room for <a href="https://matrix.to/#/#nixcon-na:nixos.org">#nixcon-na:nixos.org</a>.
+        If you are interested, please join our Matrix room for
+        <a href="https://matrix.to/#/#nixcon-na:nixos.org">#nixcon-na:nixos.org</a>.
     </SectionParagraph>
 
     <SubSectionHeading id="video">Will there be video recording?</SubSectionHeading>
@@ -59,7 +56,7 @@ import ListItem from "../common/ListItem.astro";
                         Head to Terminal B Lower Level and take the <a href="https://www.flylax.com/flyaway-bus">FlyAway Bus</a> to <a href="https://metrolinktrains.com/rider-info/general-info/stations/l.a.-union-station/">Union Station</a>.
                     </ListItem>
                     <ListItem>
-                        Take the Metro A Line to <em>Memorial Park Station or Del Mar Station</em>, both stations are 0.4 mile away from the covnention center and about a ten minute walk.
+                        Take the Metro A Line to <em>Memorial Park Station or Del Mar Station</em>, both stations are 0.4 mile away from the convention center and about a ten minute walk.
                     </ListItem>
                 </List>
             </BlockListBody>
@@ -95,7 +92,7 @@ import ListItem from "../common/ListItem.astro";
 
                     </ListItem>
                     <ListItem>
-                        Take the Metro A Line to <em>Memorial Park Station or Del Mar Station</em>, both stations are 0.4 mile away from the covnention center and about a ten minute walk.
+                        Take the Metro A Line to <em>Memorial Park Station or Del Mar Station</em>, both stations are 0.4 mile away from the convention center and about a ten minute walk.
                     </ListItem>
                 </List>
             </BlockListBody>


### PR DESCRIPTION
- remove sample text
- fix typo
- make schedule more apparent in about page

There is more template text which has been removed by #35. Can we get this merged.

I think the schedule page should be more apparent. It is the most important information for someone choosing to attend NixCon. I am open to opinions on how to do this.

