### PR TITLE
preview: deploy from pr branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,13 +1,13 @@
 name: Build and Preview
 
 on:
-  pull_request_target:
+  pull_request:
     types:
-      - edited
       - opened
       - synchronize
       - reopened
       - closed
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Description

Fixes: #39 

Reference the correct branch when generating a preview. Also included `workflow_dispatch` do you can trigger the workflow on the fly for easy testing.

Assuming the preview works as expected but this might require being merged prior to being able to test it since I cant remeber which .github/workflows gh-actions reads.