### PR TITLE
Ci/fix update workflow again

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -18,12 +18,6 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
 
-      - name: Setup Nix
-        uses: DeterminateSystems/nix-installer-action@v4
-
-      - name: Setup Magic Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v2
-
       - name: npm Install
         run: npm i
 
@@ -32,26 +26,3 @@ jobs:
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
-
-      - name: Change config for PR preview build
-        run: |
-          sed -i '11 i  "base": "/pr-preview/pr-${{ github.event.number }}",' astro.config.mjs
-
-      - name: Build
-        run: |
-          nix build
-
-      - name: Copy build result
-        run: |
-          cp -rv $(readlink -f result) out
-
-      - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
-        with:
-          source-dir: ./out/
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: website
-          path: out/**

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -31,12 +31,11 @@ jobs:
         run: npm run fetch-data
 
       - name: Create Pull Request
-        id: cpr
         uses: peter-evans/create-pull-request@v6
 
       - name: Change config for PR preview build
         run: |
-          sed -i '11 i  "base": "/pr-preview/pr-${{ steps.cpr.outputs.pull-request-number }}",' astro.config.mjs
+          sed -i '11 i  "base": "/pr-preview/pr-${{ github.event.number }}",' astro.config.mjs
 
       - name: Build
         run: |


### PR DESCRIPTION
I tried to add the deploy preview to this workflow but apparently that isn't possible without some token shenanigans. Easiest workaround is to close PRs created by the create-pull-requests action and re-open them.

See the following for other work around options.
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs