### PR TITLE
 ci/remove fetch from deploy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,6 @@ jobs:
 
       - run: npm i
 
-      - name: Fetch Schedule data
-        run: npm run fetch-data
-
       - name: Change config for PR preview build
         run: |
           sed -i '11 i  "base": "/pr-preview/pr-${{ github.event.number }}",' astro.config.mjs

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,7 +37,6 @@ jobs:
           packages: bun
           script: |
             bun install
-            bun run fetch-data
             bun run build
 
       - name: Deploy 🚀


### PR DESCRIPTION
Don't fetch the schedule for every deploy. This has been moved to an update workflow that creates PRs.