### PR TITLE
ci/remove cron from deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    # rebuild website once an hour
-    - cron:  '23 * * * *'
   workflow_dispatch: # allows manual triggering
 
 


### PR DESCRIPTION
We don't need to rebuild the site constanly any more. Updating the schedule has been moved to another workflow that makes PRs.